### PR TITLE
Inline support fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ The following [critical config properties](https://github.com/addyosmani/critica
 - **`css`** - set to the css files that are generated in the Rollup build
 - **`base`** - property is set to `criticalBase`
 - **`src`** - derived from `criticalUrl` and `criticalPages.uri`
-- **`target`** - derived from `criticalPages.template` with `_critical.min.css` appended to it
-
+- **`target`** - derived from `criticalPages.template` with `_critical.min.css` appended to it. If the `inline` option is set to `true`, the suffix `.html` is appended instead.
 ## License
 
 [MIT](LICENSE) © [nystudio107](https://nystudio107.com)

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,8 @@ function PluginCritical(pluginConfig: CriticalPluginConfig, callback?: Function)
       for (const page of pluginConfig.criticalPages) {
         const criticalBase = pluginConfig.criticalBase;
         const criticalSrc = pluginConfig.criticalUrl + page.uri;
-        const criticalDest = page.template + criticalSuffix;
+        // If inline is set to true, use HTML as target, otherwise CSS with suffix
+        const criticalTarget = (pluginConfig.criticalConfig && pluginConfig.criticalConfig.inline == true) ? page.template + ".html" : page.template + criticalSuffix;
         // Merge in our options
         const options = Object.assign(
             { css },
@@ -55,12 +56,12 @@ function PluginCritical(pluginConfig: CriticalPluginConfig, callback?: Function)
             {
               base: criticalBase,
               src: criticalSrc,
-              target: criticalDest,
+              target: criticalTarget,
             },
             pluginConfig.criticalConfig
         );
         // Generate the Critical CSS
-        console.log(`Generating critical CSS from ${criticalSrc} to ${criticalDest}`);
+        console.log(`Generating critical CSS from ${criticalSrc} to ${criticalTarget}`);
         await critical.generate(options, (err: string) => {
           if (err) {
             console.error(err);


### PR DESCRIPTION
### Description
Adds basic support for the `inline` option in `criticalConfig`. If `inline` is `true`, the output target will be HTML, if it is set to `false` or not present, the output will be CSS.

### Related issues
This solves 
https://github.com/nystudio107/rollup-plugin-critical/issues/4