### PR TITLE
Use named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i -D rollup-plugin-critical
 ```js
 // rollup.config.js
 
-import critical from 'rollup-plugin-critical'
+import { PluginCritical as critical } from 'rollup-plugin-critical';
 
 export default {
   input: 'index.js',


### PR DESCRIPTION
### Description

Without this, I run into type issues:

```TS2349: This expression is not callable.   Type 'typeof import("…node_modules/rollup-plugin-critical/dist/index")' has no call signatures.```

### Related issues
