### PR TITLE
docs: update example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export default {
     format: 'es',
   },
   plugins: [
-    PluginCritical({
+    PluginCritical.default({
         criticalUrl: 'https://nystudio107.com/',
         criticalBase: './',
         criticalPages: [


### PR DESCRIPTION
### Description
Fix error `Vite build error: TypeError: PluginCritical is not a function` when running plugin on Vite 4.3.9


### Related issues
https://github.com/nystudio107/rollup-plugin-critical/issues/12