### PR TITLE
update Critical version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test-dev": "vitest"
   },
   "dependencies": {
-    "critical": "^5.0.0"
+    "critical": "^7.0.0"
   },
   "devDependencies": {
     "@antfu/ni": "^0.21.0",


### PR DESCRIPTION
### Description
Our deploys were failing on Buddy because the build step was timing out when generating critical css.  Bumping up Critical to a more recent version worked.


### Related issues
