### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/nystudio107/rollup-plugin-critical",
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/nystudio107/rollup-plugin-critical"
+    "url": "git+https://github.com/nystudio107/rollup-plugin-critical.git"
   },
   "bugs": {
     "url": "https://github.com/nystudio107/rollup-plugin-critical/issues"


### PR DESCRIPTION
## Summary
- update the npm repository URL from SSH-style metadata to the public `git+https` GitHub URL
- leave homepage, bugs metadata, runtime files, dependencies, and package contents unchanged

## Validation
- node package metadata assertion
- npm ci --ignore-scripts
- npm run check
- npm run build
- npm pack --dry-run --ignore-scripts --json .
- git diff --check

Note: `npm run test-ci` currently fails in this local checkout because Puppeteer reports `Browser is not downloaded`; this is from installing with `--ignore-scripts` to avoid install-time browser downloads, not from the package metadata change.